### PR TITLE
no intercept when fitting

### DIFF
--- a/scepia/sc.py
+++ b/scepia/sc.py
@@ -263,7 +263,7 @@ def relevant_cell_types(
     cell_types = pd.DataFrame(index=X.columns)
 
     for col in expression.columns:
-        g.fit(X, expression[col])
+        g.fit(X, expression[col], fit_intercept=False)
         coefs = pd.DataFrame(g.coef_, index=X.columns)
         cell_types[col] = coefs
 


### PR DESCRIPTION
This requires some more thought. Not sure if fitting the intercept makes sense here. As the data should already be centered.

```
fit_interceptbool, default=True

    Whether to calculate the intercept for this model. If set to false, no intercept will be used in calculations (i.e. data is expected to be centered).
```